### PR TITLE
Fix syntax errors in source

### DIFF
--- a/Cogs/General.py
+++ b/Cogs/General.py
@@ -244,15 +244,15 @@ query ($name: String, $page: Int, $perPage: Int) {
         async with self.bot.pool.connection() as conn, conn.cursor() as curr:
             anilistID = await self.find_(user.id, curr)
 
-                if anilistID is None:
-                    await interaction.followup.send(
-                        content=f"{user.mention} is not linked to any Anilist account. Use `/set` to link one.",
-                        allowed_mentions=AllowedMentions.none(),
-                    )
-                    return
+            if anilistID is None:
+                await interaction.followup.send(
+                    content=f"{user.mention} is not linked to any Anilist account. Use `/set` to link one.",
+                    allowed_mentions=AllowedMentions.none(),
+                )
+                return
 
-                if await self.update_(_list=_list, discordId=user.id, anilistId=anilistID, force=force, pool=self.bot.pool):
-                    await interaction.followup.send("Successfully updated your list.")
+            if await self.update_(_list=_list, discordId=user.id, anilistId=anilistID, force=force, pool=self.bot.pool):
+                await interaction.followup.send("Successfully updated your list.")
 
 
 async def setup(bot):

--- a/Cogs/Mod.py
+++ b/Cogs/Mod.py
@@ -27,18 +27,14 @@ class Mod(Cog):
                 await ctx.send("Query executed.")
                 result = str(await curr.fetchall())
                 try:
-                    await curr.execute(sql_query)
-                    await ctx.send("Query executed.")
-                    result = str(await curr.fetchall())
-                    try:
-                        await ctx.send("Result:\n```" + result + "```")
-                    except HTTPException:
-                        with open("result.txt", "w") as f:
-                            f.write(result)
-                        await ctx.send(content="Result:\n", file=File("result.txt"))
-                        remove("result.txt")
-                except BaseException:
-                    await ctx.send(format_exc())
+                    await ctx.send("Result:\n```" + result + "```")
+                except HTTPException:
+                    with open("result.txt", "w") as f:
+                        f.write(result)
+                    await ctx.send(content="Result:\n", file=File("result.txt"))
+                    remove("result.txt")
+            except BaseException:
+                await ctx.send(format_exc())
 
     @command(name="prepare", hidden=True)
     @is_owner()


### PR DESCRIPTION
You recently reported some false positives on DeepSource, about the issue "**FLK-E999**: Invalid Syntax".

Howeever, the reports seem to be legitimate, and I've tried to fix them for you:
- The `if anilistID is not None:` block was indented without reason.
- The `try:` block was duplicated, and had no matching `except:` or `finally:` block.